### PR TITLE
Store old index for breach before reindexing

### DIFF
--- a/scripts/resort-breaches.js
+++ b/scripts/resort-breaches.js
@@ -72,6 +72,7 @@ db.breaches.forEach((breach, idx) => {
   if(!breach.IsRetired){
     i++
   }
+  breach.oldindex=breach.index
   breach.index = i;
 })
 


### PR DESCRIPTION
Assign old index to breach before updating the index.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store the previous index on each breach as oldindex before reindexing so we can track changes and update references after resorting. This prevents losing the original index when retired breaches are skipped.

<sup>Written for commit aca675f7ef1549bcf32c776b08ce4776b0e95213. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

