### PR TITLE
docs: ajouter les slugs en doublon identifiés dans breaches.json

### DIFF
--- a/slugs-a-supprimer.txt
+++ b/slugs-a-supprimer.txt
@@ -31,3 +31,7 @@ sfr-fuite-du-2025-12-17
 auchan-fuite-du-2024-11-19
 direct-assurance-fuite-du-2024-11-19
 red-by-sfr-fuite-du-2025-12-19
+allo-pneus-fuite-du-2026-3-27
+airsoft-entrepot-fuite-du-2026-3-26
+easy-cash-fuite-du-2025-4-22
+cerballiance-fuite-du-2026-3-25


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added four duplicated breach slugs to `slugs-a-supprimer.txt` to keep `breaches.json` de-duplicated and slugs unique. This prevents double entries during data import and reporting.

- **Bug Fixes**
  - Marked as duplicates: `allo-pneus-fuite-du-2026-3-27`, `airsoft-entrepot-fuite-du-2026-3-26`, `easy-cash-fuite-du-2025-4-22`, `cerballiance-fuite-du-2026-3-25`

<sup>Written for commit 734105da485af4ca6072d479207684bfc88bec00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal management list with four new entries scheduled for future removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->