### PR TITLE
Potential fix for code scanning alert no. 6: Incomplete URL substring sanitization

### DIFF
--- a/update-breach-links.js
+++ b/update-breach-links.js
@@ -13,7 +13,7 @@ function isLienFromHaveIBeenPwned(lien) {
   }
   try {
     const parsed = new URL(lien);
-    return parsed.hostname === 'haveibeenpwned.com';
+    return parsed.hostname === 'haveibeenpwned.com' || parsed.hostname === 'www.haveibeenpwned.com';
   } catch (e) {
     // Not a valid URL; conservatively treat as not from haveibeenpwned.com
     return false;

--- a/update-breach-links.js
+++ b/update-breach-links.js
@@ -3,8 +3,22 @@
 const fs = require('fs');
 const path = require('path');
 const { getBreachesDB } = require('./scripts/db');
+const { URL } = require('url');
 
 const baseDir = process.cwd();
+
+function isLienFromHaveIBeenPwned(lien) {
+  if (!lien || typeof lien !== 'string') {
+    return false;
+  }
+  try {
+    const parsed = new URL(lien);
+    return parsed.hostname === 'haveibeenpwned.com';
+  } catch (e) {
+    // Not a valid URL; conservatively treat as not from haveibeenpwned.com
+    return false;
+  }
+}
 
 async function run() {
 console.log('Chargement des données...');
@@ -38,8 +52,13 @@ data.breaches.forEach((breach, index) => {
     
     //if (!isImage && !isPdf) {
       // C'est une URL valide vers une page web
-      if (!breach.lien || breach.lien === 'undefined' || breach.lien.includes('undefined') || breach.lien.includes('haveibeenpwned.com')) {
-        breach.lien = breach.source||breach.path;
+      if (
+        !breach.lien ||
+        breach.lien === 'undefined' ||
+        breach.lien.includes('undefined') ||
+        isLienFromHaveIBeenPwned(breach.lien)
+      ) {
+        breach.lien = breach.source || breach.path;
         updatedCount++;
         console.log(`  ✓ Lien mis à jour pour: ${breach.Name || breach.Title}`);
       }

--- a/update-breach-links.js
+++ b/update-breach-links.js
@@ -52,12 +52,14 @@ data.breaches.forEach((breach, index) => {
     
     //if (!isImage && !isPdf) {
       // C'est une URL valide vers une page web
+      const lienValue = typeof breach.lien === 'string' ? breach.lien : '';
       if (
-        !breach.lien ||
-        breach.lien === 'undefined' ||
-        breach.lien.includes('undefined') ||
-        isLienFromHaveIBeenPwned(breach.lien)
+        !lienValue ||
+        lienValue === 'undefined' ||
+        lienValue.includes('undefined') ||
+        isLienFromHaveIBeenPwned(lienValue)
       ) {
+        breach.lien = breach.source || breach.path;
         breach.lien = breach.source || breach.path;
         updatedCount++;
         console.log(`  ✓ Lien mis à jour pour: ${breach.Name || breach.Title}`);


### PR DESCRIPTION
Potential fix for [https://github.com/alphaleadership/feed/security/code-scanning/6](https://github.com/alphaleadership/feed/security/code-scanning/6)

In general, instead of checking `someUrl.includes('trusted.com')`, you should parse the URL with a proper URL parser and inspect its `host` (or `hostname`) field, then compare that field against an explicit list of allowed hostnames using exact equality (or a well-defined rule for subdomains). This ensures that `trusted.com` is actually the host being contacted, not just a substring anywhere in the string.

Here, the minimal fix is to replace `breach.lien.includes('haveibeenpwned.com')` with a host-based check. Since this script already runs in Node.js, we can safely use the standard `URL` class from the built-in `url`/WHATWG URL implementation without adding dependencies. We’ll (1) import `URL` from Node’s `url` module, (2) add a small helper function `isLienFromHaveIBeenPwned(lien)` that safely parses a string and returns `true` only when its `hostname` is exactly `haveibeenpwned.com` (optionally also handling `www.haveibeenpwned.com` if desired), and (3) use that helper in the condition on line 41 instead of `.includes('haveibeenpwned.com')`. This keeps behavior essentially the same for true HIBP links while avoiding false positives where the domain just appears in the path or query. All changes are confined to `update-breach-links.js`: adding one import, defining one helper function near the top, and updating the `if` condition on line 41.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes code scanning alert #6 by replacing substring URL checks with strict hostname validation in `update-breach-links.js`. Only `haveibeenpwned.com` and `www.haveibeenpwned.com` are accepted; invalid or non-string links are handled safely.

- **Bug Fixes**
  - Added `isLienFromHaveIBeenPwned()` using Node’s `URL` to verify exact hostname.
  - Normalized `breach.lien` to a string and replaced `.includes('haveibeenpwned.com')` with the helper; existing `undefined` guards kept; no new dependencies.

<sup>Written for commit fd3af7404cb20e7db552f1c16252442df7de5b2c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved breach link validation to only accept properly formed URLs and exact matches for the Have I Been Pwned domain, reducing false positives.
  * Better handling of missing, empty, or malformed link values so displayed breach links are more accurate and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->