### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete URL substring sanitization

### DIFF
--- a/tools/resort-breaches.js
+++ b/tools/resort-breaches.js
@@ -9,6 +9,25 @@ const { getBreachesDB } = require('../scripts/db');
 
 const baseDir = process.cwd();
 
+/**
+ * Safely extract the hostname from a URL string.
+ * Returns an empty string if the URL is invalid or cannot be parsed.
+ */
+function getHostnameFromUrl(urlString) {
+  if (typeof urlString !== 'string' || urlString.trim() === '') {
+    return '';
+  }
+  try {
+    // Support both absolute and protocol-relative URLs by ensuring a scheme.
+    const hasScheme = /^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(urlString);
+    const normalized = hasScheme ? urlString : 'https://' + urlString;
+    const parsed = new URL(normalized);
+    return parsed.hostname.toLowerCase();
+  } catch (e) {
+    return '';
+  }
+}
+
 // Initialize the NSFWDetector
 const nsfwDetector = new NSFWDetector(
   path.join(baseDir, '.kiro', 'specs', 'nsfw-detection-system', 'config.json'),
@@ -153,9 +172,19 @@ async function processBreaches() {
 
     // Détermination de la source
     if (!breach.source) {
-      if (breach.path && breach.path.includes('breaches/')) breach.source = 'Have I Been Pwned';
-      else if (breach.lien && breach.lien.includes('zataz.com')) breach.source = 'Zataz';
-      else breach.source = 'Manuel';
+      if (breach.path && breach.path.includes('breaches/')) {
+        breach.source = 'Have I Been Pwned';
+      } else if (breach.lien) {
+        const host = getHostnameFromUrl(breach.lien);
+        const allowedZatazHosts = ['zataz.com', 'www.zataz.com'];
+        if (allowedZatazHosts.includes(host)) {
+          breach.source = 'Zataz';
+        } else {
+          breach.source = 'Manuel';
+        }
+      } else {
+        breach.source = 'Manuel';
+      }
     }
 
     // Correction des liens pour les sources manuelles


### PR DESCRIPTION
Potential fix for [https://github.com/alphaleadership/feed/security/code-scanning/7](https://github.com/alphaleadership/feed/security/code-scanning/7)

In general, to correctly check if a URL belongs to a given site, you should parse the URL and inspect its hostname (or origin), not search for a substring in the full URL string. Then compare the hostname against a whitelist of allowed hostnames, or verify that it matches an expected domain or its subdomains in a safe way.

For this specific case, the best fix without changing functional intent is: instead of `breach.lien.includes('zataz.com')`, parse `breach.lien` via the built-in `URL` class, extract the `hostname`, and compare it against an explicit allowlist of Zataz hostnames (for example `['zataz.com', 'www.zataz.com']`). This keeps the behavior of classifying a breach as `Zataz` when its URL truly points to Zataz, while avoiding false positives where `'zataz.com'` appears in the path or query or as part of a different domain.

Concretely, in `tools/resort-breaches.js` around line 155–158:

- Introduce a small helper to safely extract the hostname from a URL string, wrapping `new URL()` in a try/catch so that invalid URLs don’t crash the script.
- Replace `breach.lien && breach.lien.includes('zataz.com')` with logic that:
  - Gets the hostname of `breach.lien`.
  - Checks that this hostname is present in an `allowedZatazHosts` array. You can define this array right next to the check to keep things self-contained.
This uses only built-in Node.js functionality (`URL`) and does not require new imports.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes code scanning alert #7 by replacing unsafe substring URL checks with hostname parsing and an allowlist for Zataz links. This prevents false positives while keeping breach source detection accurate.

- **Bug Fixes**
  - Added `getHostnameFromUrl` helper using the built-in `URL` API (handles missing schemes and invalid URLs).
  - Replaced `breach.lien.includes('zataz.com')` with an allowlist check on hostnames: `['zataz.com', 'www.zataz.com']`.
  - Keeps existing HIBP path check; defaults to `Manuel` when the hostname doesn’t match.
  - No new dependencies.

<sup>Written for commit ac761f3c7825f35efae6781723dfc70e329dfc70. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved breach source attribution through refined hostname matching for enhanced data accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->