### PR TITLE
Potential fix for code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/update-breach-links.js
+++ b/update-breach-links.js
@@ -37,11 +37,18 @@ data.breaches.forEach((breach, index) => {
     breach.Domain = "francetravail.fr";
   }
   // Pour les fuites bonjourlafuite, utiliser le champ path comme lien
-  if (breach.path && breach.path.includes('bonjourlafuite.eu.org') && breach.path) {
-    // Construire l'URL bonjourlafuite
-    breach.lien = `${breach.path}`;
-    updatedCount++;
-    console.log(`  ✓ Lien bonjourlafuite mis à jour pour: ${breach.Name || breach.Title} ${breach.lien}`);
+  if (breach.path) {
+    try {
+      const parsedBonjour = new URL(breach.path, 'https://bonjourlafuite.eu.org');
+      if (parsedBonjour.hostname === 'bonjourlafuite.eu.org') {
+        // Construire l'URL bonjourlafuite
+        breach.lien = `${breach.path}`;
+        updatedCount++;
+        console.log(`  ✓ Lien bonjourlafuite mis à jour pour: ${breach.Name || breach.Title} ${breach.lien}`);
+      }
+    } catch (e) {
+      // Si breach.path n'est pas une URL ou un chemin valide, on l'ignore simplement
+    }
   }
  
   // Vérifier si la source commence par https et n'est pas une image


### PR DESCRIPTION
Potential fix for [https://github.com/alphaleadership/feed/security/code-scanning/5](https://github.com/alphaleadership/feed/security/code-scanning/5)

In general, to fix this kind of issue you should not use `String.prototype.includes` (or other substring tests) on a full URL to decide whether it belongs to a specific host or domain. Instead, parse the URL using a URL parser, extract its hostname, and compare that hostname (or a well-defined set of allowed hostnames) against a whitelist.

In this file, the risky logic is:

```js
// Pour les fuites bonjourlafuite, utiliser le champ path comme lien
if (breach.path && breach.path.includes('bonjourlafuite.eu.org') && breach.path) {
  // Construire l'URL bonjourlafuite
  breach.lien = `${breach.path}`;
  ...
}
```

We already import `URL` from the `url` module and use it in `isLienFromHaveIBeenPwned`, so we can reuse the same approach. The best minimal change is:

- Replace the substring check on `breach.path` with a proper URL host check.
- To handle both full URLs (`https://bonjourlafuite.eu.org/...`) and possibly path-only values (`/some/path`), use the WHATWG `URL` constructor with a fixed base, such as `https://bonjourlafuite.eu.org`. This way, if `breach.path` is a relative path, it will be interpreted under that base domain; if it is an absolute URL, that URL’s own host will be used.
- Then set `breach.lien` only when the resulting hostname is `bonjourlafuite.eu.org` (or possibly `www.bonjourlafuite.eu.org` if that’s valid in your data).

Concretely:

1. Introduce a small helper inline in the existing `if`-block using `new URL(breach.path, 'https://bonjourlafuite.eu.org')` in a `try/catch` to avoid crashes on malformed URLs.
2. Check `parsed.hostname === 'bonjourlafuite.eu.org'` (and any additional legitimate host variants if needed).
3. Only in that case, set `breach.lien = breach.path` and increment `updatedCount` as before.

This preserves existing functionality for legitimate `bonjourlafuite.eu.org` links while avoiding accepting arbitrary URLs that merely contain that string somewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced substring checks with strict hostname validation for `bonjourlafuite.eu.org` links to address code scanning alert 5 and prevent false positives. Only valid links now update `breach.lien`.

- **Bug Fixes**
  - Parse `breach.path` with `new URL(breach.path, 'https://bonjourlafuite.eu.org')` in a try/catch to support absolute and relative paths.
  - Set `breach.lien` only when `parsedBonjour.hostname === 'bonjourlafuite.eu.org'`.
  - Removed `String.prototype.includes` domain check to avoid incomplete sanitization.

<sup>Written for commit 9a2480301e66ffcf72774bba5c032376ea49898b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link validation and error handling to ensure more accurate link processing and verification. The system now gracefully skips invalid or malformed links instead of attempting to process them. These enhancements significantly improve overall data quality, system stability, and accuracy when managing link information across the platform and integrated services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->