### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/themes/freemind/source/js/gallery.js
+++ b/themes/freemind/source/js/gallery.js
@@ -4,11 +4,14 @@
     $(this).find('img').each(function(){
       if (!$(this).hasClass('nofancybox')){
         var alt = this.alt;
+        var $link = $('<a></a>')
+          .attr('href', this.src)
+          .addClass('fancybox')
+          .attr('rel', 'gallery' + i);
         if (alt){
-          $(this).wrap('<a href="' + this.src + '" title="' + alt + '" class="fancybox" rel="gallery' + i + '" />');
-        } else {
-          $(this).wrap('<a href="' + this.src + '" class="fancybox" rel="gallery' + i + '" />');
-	    }
+          $link.attr('title', alt);
+        }
+        $(this).wrap($link);
       }
     });
   });


### PR DESCRIPTION
Potential fix for [https://github.com/alphaleadership/feed/security/code-scanning/8](https://github.com/alphaleadership/feed/security/code-scanning/8)

In general, the fix is to avoid taking text/attribute values from the DOM and reinterpreting them as HTML by concatenating them into HTML strings. Instead, construct elements as real DOM nodes, then assign attribute values via the DOM API (`.attr()` / `.prop()` / `setAttribute`) so that jQuery/DOM will handle any necessary escaping and prevent HTML/meta-character interpretation.

For this specific file, the vulnerable part is on lines 8–10, where `alt` and `this.src` are concatenated into a string passed to `$(this).wrap(...)`. The best fix without changing user-visible behavior is:

- Create an `<a>` element via jQuery without unsafe content (`$('<a></a>')`).
- Set its `href`, `title`, `class`, and `rel` attributes using `.attr()`.
- Wrap the image element using that safe jQuery object instead of an HTML string.

This preserves the exact attributes and values (including the gallery index) while ensuring that any special characters in `alt` or `src` are treated as data, not HTML. Concretely, in `themes/freemind/source/js/gallery.js`, replace the two `wrap('<a ... />')` calls in the caption block (lines 8–10) with code that builds the anchor element via jQuery and sets attributes programmatically.

No new methods or external libraries are needed; we only use existing jQuery.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes code scanning alert #8 by safely wrapping gallery images with anchors created via `jQuery` APIs instead of HTML strings in `themes/freemind/source/js/gallery.js`.

- **Bug Fixes**
  - Replaced string-based `wrap('<a ... />')` with ` $('<a></a>').attr(...)` and `addClass('fancybox')`.
  - Sets `href`, `rel`, and `title` via `.attr()`; only adds `title` when `alt` exists.
  - Prevents `alt`/`src` being interpreted as HTML, reducing XSS risk without changing behavior.

<sup>Written for commit bc06b9e419403c5465dede5bb7a6484ab7305da1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

