### PR TITLE
Potential fix for code scanning alert no. 13: Incomplete multi-character sanitization

### DIFF
--- a/clean-html-tags.js
+++ b/clean-html-tags.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const sanitizeHtml = require('sanitize-html');
 
 const baseDir = path.join(__dirname, '.');
 const dataFile = path.join(baseDir, 'source', '_data', 'breaches.json');
@@ -18,9 +19,12 @@ function removeHtmlTags(text) {
   if (!text || typeof text !== 'string') {
     return text;
   }
-  
-  // Enlever les balises HTML
-  return text.replace(/<[^>]*>/g, '').replaceAll("&gt;","");
+
+  // Enlever les balises HTML en utilisant une bibliothèque de sanitisation
+  return sanitizeHtml(text, {
+    allowedTags: [],
+    allowedAttributes: {}
+  });
 }
 
 db.breaches.forEach((breach, index) => {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
     "lowdb": "^7.0.1",
     "resend": "^6.10.0",
     "rss-parser": "^3.13.0",
-    "sudoku": "^0.0.3"
+    "sudoku": "^0.0.3",
+    "sanitize-html": "^2.17.2"
   },
   "devDependencies": {
     "gray-matter": "^4.0.3"


### PR DESCRIPTION
Potential fix for [https://github.com/alphaleadership/feed/security/code-scanning/13](https://github.com/alphaleadership/feed/security/code-scanning/13)

In general, the robust fix is to use a well-tested HTML sanitization library and configure it appropriately instead of relying on a hand-rolled regex to remove tags. Libraries correctly handle nested tags, malformed markup, and entity decoding, and avoid the incomplete multi-character sanitization issue.

Here, the single best fix that preserves intent (“remove HTML tags from descriptions/content”) is to replace the regex-based removal with a library call that strips HTML tags and unsafe content. A good, well-known option in Node.js is `sanitize-html`. We will:

- Require `sanitize-html` at the top of `clean-html-tags.js`.
- Rewrite `removeHtmlTags` to call `sanitizeHtml` with a configuration that strips all tags and attributes, returning plain text.
- Remove the ad-hoc `.replaceAll("&gt;","")`, which is both incomplete and unnecessary once a sanitizer is used.

Concretely:
- Around line 3–5, add `const sanitizeHtml = require('sanitize-html');`.
- Replace the body of `removeHtmlTags` (lines 17–24) so that, after the type check, it returns `sanitizeHtml(text, { allowedTags: [], allowedAttributes: {} });`. This configuration drops all tags and keeps only text content.
- Keep the rest of the script unchanged.

This directly addresses the CodeQL warning by eliminating the fragile regex and using a multi-pass, tested sanitizer.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace fragile regex-based HTML stripping with `sanitize-html` in `clean-html-tags.js` to safely return plain text and resolve CodeQL alert 13 (incomplete multi-character sanitization).

- **Bug Fixes**
  - Use `sanitize-html` with `allowedTags: []` and `allowedAttributes: {}` to strip all HTML.
  - Remove regex and `.replaceAll("&gt;","")`; handles nested/malformed tags and entities correctly.

- **Dependencies**
  - Add `sanitize-html@^2.17.2`.

<sup>Written for commit 3b249c25ee9fbff00d2f204326c20d18517b55b8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTML tag removal with enhanced sanitization for more reliable and robust cleaning of HTML content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->